### PR TITLE
Force use of jackson-databind@2.8.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
 			<artifactId>tinylog</artifactId>
 			<version>1.2</version>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.8.9</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>2.8.9</version>
 		</dependency>
+		<dependency>
+			<groupId>com.thoughtworks.xstream</groupId>
+			<artifactId>xstream</artifactId>
+			<version>1.4.9</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Force use of jackson-databind@2.8.9 because of https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7525 .