### PR TITLE
Force jackson-databind@2.8.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.8.9</version>
+			<version>2.8.11.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>


### PR DESCRIPTION
Force jackson-databind@2.8.11.1 to fix https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7489